### PR TITLE
Add callback to modify measured coordinates

### DIFF
--- a/src/utils/Measure.js
+++ b/src/utils/Measure.js
@@ -614,7 +614,7 @@ export class Measure extends THREE.Object3D {
 			{ // coordinate labels
 				let coordinateLabel = this.coordinateLabels[0];
 				
-				let msg = position.toArray().map(p => Utils.addCommas(p.toFixed(2))).join(" / ");
+				let msg = this.measureCoordinateCallback(position).toArray().map(p => Utils.addCommas(p.toFixed(2))).join(" / ");
 				coordinateLabel.setText(msg);
 
 				coordinateLabel.visible = this.showCoordinates;

--- a/src/utils/MeasuringTool.js
+++ b/src/utils/MeasuringTool.js
@@ -170,6 +170,7 @@ export class MeasuringTool extends EventDispatcher{
 		let domElement = this.viewer.renderer.domElement;
 
 		let measure = new Measure();
+		measure.measureCoordinateCallback = this.viewer.measureCoordinateCallback;
 
 		this.dispatchEvent({
 			type: 'start_inserting_measurement',

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -322,6 +322,8 @@ export class Viewer extends EventDispatcher{
 
 		this.loadGUI = this.loadGUI.bind(this);
 
+		this.measureCoordinateCallback = args.measureCoordinateCallback || (value => value);
+		
 		this.annotationTool = new AnnotationTool(this);
 		this.measuringTool = new MeasuringTool(this);
 		this.profileTool = new ProfileTool(this);


### PR DESCRIPTION
add a callback parameter to Potree `viewer` constructor. This callback defines a method which is applied to the position written as text content in coordinates labels displayed with 'coordinates' tool. This allows coordinates transformation.

By default, coordinates are displayed in the view's CRS. We can convert (for example to EPSG 4326) these coordinates as such : 
```js
const potreeViewer = new Potree.Viewer(potree_rendering_area, {
    measureCoordinateCallback: (position) => {
        return coordinates.setFromVector3(position).as('EPSG:4326').toVector3();
    },
});
```